### PR TITLE
fix: revert CHANGELOG terminology and fix example indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,39 +6,38 @@
   Sipeed Cube, Yahboom and WonderMV;
 - Flash official firmware with automatic integrity/authenticity verification;
 - Flash beta firmware devices;
-- Air-gapped update devices with SDcard;
+- Air-gap update devices with SDcard;
 - Wipe devices;
 - 12 locale support;
 - support for Windows, MacOS Arm, MacOS Intel, Debian-like OS and Fedora;
 - Fixed Fedora crashes;
 - Better error handling during flash procedure;
 - Better error handling during wipe procedure;
-- Better error handling during air-gapped update procedure;
+- Better error handling during air-gap update procedure;
 
 ## 0.0.20-beta
 
 ### Major update
 
-- Make an air-gapped update:
+- Make an airgapped update:
   - user will be requested to insert a SDCard on computer;
   - user can select among recognized removable drives;
   - both `firmware.bin` and `firmware.bin.sig` will be copied to sdcard;
   - after the copy, user will be requested to eject sdcard and insert it on
     device;
   - at same time, the `firmware.bin`'s computed hash will appear to compare
-    with the computed hash
-    on device;
+    with the computed hash on device;
 
 ### Minor updates
 
 - Added support to de_DE locale;
 - Added support to ja_JP locale;
-- Fixed Windows bug that didn't allow users to select a custom asset folder;
+- Fixes on Windows bug that didn't allow users to select a custom asset folder;
 
 ## 0.0.20-alpha-3
 
 - Fix the bug that crash when a new firmware version is added on
-  `selfcustody/krux`, but it isn't listed as a valid one in
+  `selfcustody/krux`, but not it isnt a valid one in
   `VALID_DEVICES_VERSIONS`;
 - The fix suggested by @odudex to manage new versions (good when a hot fix is
   made) in line 101 of `src/app/screens/select_device_screen.py`;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ def foo(
     bar: int,
     baz: float,
 ) -> str:
-  str(bar) + str(baz)
+    str(bar) + str(baz)
 ```
 
 prefer:


### PR DESCRIPTION
- Revert CHANGELOG terminology changes back to original wording (per AGENT.md: formatting fixes OK, content rewrites not);
- Fix 2-space to 4-space indentation in bad Python example;
- Reflow 'on device' orphan line;